### PR TITLE
nginx extension

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.env*
+docker-compose.yml
+Dockerfile
+README.md
+LICENSE

--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-# Path to ava node
-RPC_URL=http://localhost:9650/ext/bc/C/rpc
-
-# Local path for url-request
-LOCAL_URL=/rpc
-
-# Local port for url-request
-NGINX_PORT=4444

--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Path to ava node
+RPC_URL=http://localhost:9650/ext/bc/C/rpc
+
+# Local path for url-request
+LOCAL_URL=/rpc
+
+# Local port for url-request
+NGINX_PORT=4444

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ LOCAL_URL=/rpc
 
 # Local port for url-request
 NGINX_PORT=4444
+
+# Options for binary ava file
+AVA_CMD_OPTIONS=--db-dir /db

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Path to ava node
+RPC_URL=http://localhost:9650/ext/bc/C/rpc
+
+# Local path for url-request
+LOCAL_URL=/rpc
+
+# Local port for url-request
+NGINX_PORT=4444

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ awscpu
 *.dylib
 *.profile
 
+.env
 # Test binary, build with `go test -c`
 *.test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,12 @@
 
 FROM golang:1.13.4-buster AS builder
 
-RUN mkdir -p /go/src/github.com/ava-labs
 WORKDIR /src/github.com/ava-labs/
 COPY . gecko
 WORKDIR /src/github.com/ava-labs/gecko
 RUN ./scripts/build.sh
 
-FROM nginx
+FROM nginx:latest
 
 COPY --from=builder /src/github.com/ava-labs/gecko/build /build
 COPY entrypoint.sh nginx.template ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ COPY . gecko
 
 WORKDIR $GOPATH/src/github.com/ava-labs/gecko
 
-RUN ./scripts/build.sh
+#RUN ./scripts/build.sh
 
 CMD ["/bin/bash", "entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,18 @@
 
 FROM golang:1.13.4-buster
 
+RUN apt-get update
+
+# gettext for `envsubst` command
+RUN apt-get install -y nginx gettext
+
 RUN mkdir -p /go/src/github.com/ava-labs
 
 WORKDIR $GOPATH/src/github.com/ava-labs/
 COPY . gecko
 
 WORKDIR $GOPATH/src/github.com/ava-labs/gecko
+
 RUN ./scripts/build.sh
+
+CMD ["/bin/bash", "entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ COPY . gecko
 
 WORKDIR $GOPATH/src/github.com/ava-labs/gecko
 
-#RUN ./scripts/build.sh
+RUN ./scripts/build.sh
 
 CMD ["/bin/bash", "entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,17 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.13.4-buster
-
-RUN apt-get update
-
-# gettext for `envsubst` command
-RUN apt-get install -y nginx gettext
+FROM golang:1.13.4-buster AS builder
 
 RUN mkdir -p /go/src/github.com/ava-labs
-
-WORKDIR $GOPATH/src/github.com/ava-labs/
+WORKDIR /src/github.com/ava-labs/
 COPY . gecko
-
-WORKDIR $GOPATH/src/github.com/ava-labs/gecko
-
+WORKDIR /src/github.com/ava-labs/gecko
 RUN ./scripts/build.sh
 
+FROM nginx
+
+COPY --from=builder /src/github.com/ava-labs/gecko/build /build
+COPY entrypoint.sh nginx.template ./
+
 CMD ["/bin/bash", "entrypoint.sh"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+    ava_node:
+        build: .
+        volumes:
+            - ~/.gecko/db:/db
+            - ./nginx.template:/etc/nginx/conf.d/nginx.template
+        ports: 
+            - 4444:4444

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
     ava_node:
         build: .
+        image: poanetwork/ava-node
         volumes:
             - ~/.gecko/db:/db
             - ./nginx.template:/etc/nginx/conf.d/nginx.template

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,5 @@ services:
             - ~/.gecko/db:/db
             - ./nginx.template:/etc/nginx/conf.d/nginx.template
         ports: 
-            - 4444:4444
-        environment:
-            - RPC_URL=${RPC_URL}
-            - LOCAL_URL=${LOCAL_URL}
-            - NGINX_PORT=${NGINX_PORT}
+            - ${NGINX_PORT}:${NGINX_PORT}
+        env_file: .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,7 @@ services:
             - ./nginx.template:/etc/nginx/conf.d/nginx.template
         ports: 
             - 4444:4444
+        environment:
+            - RPC_URL=${RPC_URL}
+            - LOCAL_URL=${LOCAL_URL}
+            - NGINX_PORT=${NGINX_PORT}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,5 @@ echo "RECREATE NGINX CONFIG"
 envsubst < /etc/nginx/conf.d/nginx.template > /etc/nginx/conf.d/default.conf
 echo "START NGINX"
 service nginx start
-echo "START NODE"
-./build/ava --db-dir /db
+echo "START NODE WITH ARGS ${AVA_CMD_OPTIONS}"
+./build/ava ${AVA_CMD_OPTIONS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "RECREATE NGINX CONFIG"
+envsubst < /etc/nginx/conf.d/nginx.template > /etc/nginx/conf.d/default.conf
+echo "START NGINX"
+service nginx start
+echo "START NODE"
+./build/ava --db-dir /db

--- a/nginx.template
+++ b/nginx.template
@@ -1,0 +1,6 @@
+server {
+        listen ${NGINX_PORT};
+        location ${LOCAL_URL} {
+            proxy_pass ${RPC_URL};
+        }
+    }


### PR DESCRIPTION
Running Nginx with the ava client in the same docker container in order to allow RPC calls from external IPs.

Nginx and the ava client parameters could be provided through the `.env` file (use `.env.example` for reference).
There are four parameters suggested so far:

  * `RPC_URL` -- a full URL to the localhost where the ava client serves JSON RPC requests
  * `LOCAL_URL` -- a path in the URL serving by Nginx to forward JSON RPC requests to the ava client
  * `NGINX_PORT` -- a port that Nginx listens to receive JSON RPC request and forward them to the ava client
  * `AVA_CMD_OPTIONS` -- command line options for the ava client (e.g. where the client database is located)
